### PR TITLE
Add system:masters auth to the kube-config admin

### DIFF
--- a/lib/init-ssl
+++ b/lib/init-ssl
@@ -66,7 +66,7 @@ CONTENTS="${CAFILE} ${KEYFILE} ${PEMFILE}"
 echo "$CNF_TEMPLATE$(echo $SANS | tr ',' '\n')" > "$CONFIGFILE"
 
 $OPENSSL genrsa -out "$KEYFILE" 2048
-$OPENSSL req -new -key "$KEYFILE" -out "$CSRFILE" -subj "/CN=$CN" -config "$CONFIGFILE"
+$OPENSSL req -new -key "$KEYFILE" -out "$CSRFILE" -subj "/CN=$CN/O=system:masters" -config "$CONFIGFILE"
 $OPENSSL x509 -req -in "$CSRFILE" -CA "$CAFILE" -CAkey "$CAKEYFILE" -CAcreateserial -out "$PEMFILE" -days 365 -extensions v3_req -extfile "$CONFIGFILE"
 
 tar -cf $OUTFILE -C $OUTDIR $(for  f in $CONTENTS;do printf "$(basename $f) ";done)


### PR DESCRIPTION
Fixes the error from not being able to create an RBAC ClusterRole