### PR TITLE
Switch to calico 1.2.0 and use IP_AUTODETECTION_METHOD

### DIFF
--- a/Documentation/deploy-master.md
+++ b/Documentation/deploy-master.md
@@ -455,7 +455,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: quay.io/calico/node:v0.23.0
+          image: quay.io/calico/node:v1.2.0
           env:
             # The location of the Calico etcd cluster.
             - name: ETCD_ENDPOINTS
@@ -471,6 +471,8 @@ spec:
               value: "true"
             - name: NO_DEFAULT_POOLS
               value: "true"
+            - name: IP_AUTODETECTION_METHOD
+              value: "can-reach=172.17.4.99"
           securityContext:
             privileged: true
           volumeMounts:

--- a/multi-node/generic/controller-install.sh
+++ b/multi-node/generic/controller-install.sh
@@ -916,7 +916,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: quay.io/calico/node:v0.23.0
+          image: quay.io/calico/node:v1.2.0
           env:
             # The location of the Calico etcd cluster.
             - name: ETCD_ENDPOINTS
@@ -932,6 +932,8 @@ spec:
               value: "true"
             - name: NO_DEFAULT_POOLS
               value: "true"
+            - name: IP_AUTODETECTION_METHOD
+              value: "can-reach=172.17.4.101"
           securityContext:
             privileged: true
           volumeMounts:

--- a/single-node/user-data
+++ b/single-node/user-data
@@ -903,7 +903,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: quay.io/calico/node:v0.23.0
+          image: quay.io/calico/node:v1.2.0
           env:
             # The location of the Calico etcd cluster.
             - name: ETCD_ENDPOINTS
@@ -919,6 +919,8 @@ spec:
               value: "true"
             - name: NO_DEFAULT_POOLS
               value: "true"
+            - name: IP_AUTODETECTION_METHOD
+              value: "can-reach=172.17.4.99"
           securityContext:
             privileged: true
           volumeMounts:


### PR DESCRIPTION
When running on virtualbox, one of the interfaces
is a NAT interface, and if the calico IP autodetect
code picks that interface, things don't work.  So,
update to calico 1.2.0 so that we can use the
IP_AUTODETECTION_METHOD feature to tell calico
how to find the correct IP address.  The IP
addresses are in the same subnet as is used by
the Vagrant configuration.